### PR TITLE
Parse csv records into birthday structures

### DIFF
--- a/app/birthday.go
+++ b/app/birthday.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+// Birthday describes the structure of an expected record in the CSV
+type Birthday struct {
+	Name        string
+	Day         uint8
+	Month       uint8
+	Description string
+}
+
+func fromCSV(raw io.Reader) ([]Birthday, error) {
+	reader := csv.NewReader(raw)
+	reader.FieldsPerRecord = -1
+	reader.TrimLeadingSpace = true
+	lines, err := reader.ReadAll()
+
+	if err != nil {
+		return nil, fmt.Errorf("an error occurred while reading the csv: %w", err)
+	}
+
+	birthdays := make([]Birthday, len(lines))
+	for i, line := range lines {
+		birthdays[i], err = fromCSVLine(line)
+		if err != nil {
+			return nil, fmt.Errorf("Invalid birthday record at line %d: %w, got: [%s]", i+1, err, strings.Join(line, ","))
+		}
+	}
+
+	return birthdays, nil
+}
+
+const formatError = "expected format for CSV is: 'name','day','month','description' or 'name','day','month'"
+
+func fromCSVLine(line []string) (Birthday, error) {
+	if len(line) != 4 && len(line) != 3 {
+		return Birthday{}, fmt.Errorf(formatError)
+	}
+
+	// TODO: more strict validation of dates (31 of february should not work)
+	day, err := strconv.ParseUint(line[1], 10, 8)
+	if err != nil || day > 31 || day == 0 {
+		return Birthday{}, fmt.Errorf("invalid value for day: '%s', %s", line[1], formatError)
+	}
+
+	month, err := strconv.ParseUint(line[2], 10, 8)
+	if err != nil || month > 12 || month == 0 {
+		return Birthday{}, fmt.Errorf("invalid value for month: '%s', %s", line[2], formatError)
+	}
+
+	description := ""
+	if len(line) == 4 {
+		description = line[3]
+	}
+
+	return Birthday{
+		Name: line[0], Day: uint8(day), Month: uint8(month), Description: description}, nil
+}

--- a/app/birthday_test.go
+++ b/app/birthday_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseCSV(t *testing.T) {
+	for _, tc := range []struct {
+		input string
+		err   string
+		out   []Birthday
+	}{
+		{
+			input: "john, 27, 11, john's birthday\njane,19,04,jane's birthday\nnodesc,1,1",
+			out: []Birthday{
+				Birthday{
+					Name:        "john",
+					Day:         27,
+					Month:       11,
+					Description: "john's birthday",
+				},
+				Birthday{
+					Name:        "jane",
+					Day:         19,
+					Month:       4,
+					Description: "jane's birthday",
+				},
+				Birthday{
+					Name:  "nodesc",
+					Day:   1,
+					Month: 1,
+				},
+			},
+		},
+		{
+			input: "",
+			out:   []Birthday{},
+		},
+		{
+			input: "john,a,b,c",
+			err:   "record at line 1: invalid value for day: 'a'",
+		},
+		{
+			input: "john,10,b,c",
+			err:   "record at line 1: invalid value for month: 'b'",
+		},
+		{
+			input: "john,10,13,c",
+			err:   "record at line 1: invalid value for month: '13'",
+		},
+		{
+			input: "john,10,0,c",
+			err:   "record at line 1: invalid value for month: '0'",
+		},
+		{
+			input: "john,0,10,c",
+			err:   "record at line 1: invalid value for day: '0'",
+		},
+		{
+			input: "john,32,10,c",
+			err:   "record at line 1: invalid value for day: '32'",
+		},
+	} {
+		reader := strings.NewReader(tc.input)
+		out, err := fromCSV(reader)
+		if len(tc.err) != 0 {
+			assert.True(t, strings.Contains(fmt.Sprint(err), tc.err), fmt.Sprintf("%s should contain %s", err, tc.err))
+		} else {
+			assert.Nil(t, err)
+		}
+		assert.Equal(t, tc.out, out)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/sfluor/csv2birthcal
 
-go 1.12
+go 1.15
+
+require github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This adds the capability to parse CSVs into Birthday records that have
the following structure:

```
name,day,month,[optional: description]
```

To test:
```bash
go test ./app
```

Note: there's still validation to do on valid day/month pairs